### PR TITLE
pygrype 0.3.2 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-    - https://staging.continuum.io/prefect/fs/grype-feedstock/pr1/9c61db1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+    - https://staging.continuum.io/prefect/fs/grype-feedstock/pr1/9c61db1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # go is not available for s390x
+  skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  # go is not available for s390x
+  # grype is not available for s390x
   skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "pygrype" %}
+{% set version = "0.3.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ebbb93cf80657b36bc4eca8a07fc06d510ebbfdca3ec2fe9a0bbcd63f5e0b5d4
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - setuptools-scm
+    - pip
+    - wheel
+  run:
+    - python
+    - dacite >=1.8.1
+    - grype >=0.75.0
+
+test:
+  imports:
+    - pygrype
+  requires:
+    - pip
+    - pytest
+  source_files:
+    - test
+  commands:
+    - pip check
+    - python -c "from pygrype import Grype; print(Grype().version())"
+    - pytest -v test
+
+about:
+  home: https://github.com/willyw0nka/pygrype
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python wrapper for Grype
+  description: |
+    A python wrapper for Anchore Grype
+  doc_url: https://github.com/willyw0nka/pygrype
+  dev_url: https://github.com/willyw0nka/pygrype
+
+extra:
+  recipe-maintainers:
+    - lorepirri


### PR DESCRIPTION
pygrype 0.3.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4533] 
- dev_url: https://github.com/willyw0nka/pygrype/tree/0.3.2
- pypi: https://pypi.org/project/pygrype/0.3.2
- pypi inspector: https://inspector.pypi.io/project/pygrype/0.3.2

### Explanation of changes:

- new feedstock

### Depends on:

- AnacondaRecipes/grype-feedstock#1


[PKG-4533]: https://anaconda.atlassian.net/browse/PKG-4533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ